### PR TITLE
Add frame_id per Lidar

### DIFF
--- a/livox_ros2_driver/CMakeLists.txt
+++ b/livox_ros2_driver/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright(c) 2020 livoxtech limited.
 
 cmake_minimum_required(VERSION 3.5)
-project(livox_ros2_driver)
+project(deepx_livox_ros2_driver)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)

--- a/livox_ros2_driver/livox_ros2_driver/lddc.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lddc.cpp
@@ -150,6 +150,11 @@ uint32_t Lddc::PublishPointcloud2(LidarDataQueue *queue, uint32_t packet_num,
 
   sensor_msgs::msg::PointCloud2 cloud;
   InitPointcloud2MsgHeader(cloud);
+  std::string bdc(lidar->info.broadcast_code);
+  auto bdc_frame_id = lds_->map_frame_id.find(bdc);
+  if (bdc_frame_id != lds_->map_frame_id.end()) {
+    cloud.header.frame_id = bdc_frame_id->second;
+  }
   cloud.data.resize(packet_num * kMaxPointPerEthPacket *
                     sizeof(LivoxPointXyzrtl));
   cloud.point_step = sizeof(LivoxPointXyzrtl);

--- a/livox_ros2_driver/livox_ros2_driver/lds.h
+++ b/livox_ros2_driver/livox_ros2_driver/lds.h
@@ -35,6 +35,7 @@
 #include <vector>
 #include <mutex>
 #include <condition_variable>
+#include <unordered_map>
 
 #include "ldq.h"
 
@@ -183,6 +184,7 @@ typedef struct {
   uint32_t firmware_ver; /**< Firmware version of lidar  */
   UserConfig config;
   ExtrinsicParameter extrinsic_parameter;
+  std::string frame_id;
 } LidarDevice;
 
 typedef struct {
@@ -439,6 +441,7 @@ class Lds {
   uint8_t lidar_count_;                 /**< Lidar access handle. */
   LidarDevice lidars_[kMaxSourceLidar]; /**< The index is the handle */
   Semaphore semaphore_;
+  std::unordered_map<std::string, std::string> map_frame_id;
 
  protected:
   uint32_t buffer_time_ms_; /**< Buffer time before data in queue is read */

--- a/livox_ros2_driver/livox_ros2_driver/lds_lidar.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/lds_lidar.cpp
@@ -701,6 +701,11 @@ int LdsLidar::ParseConfigFile(const char *pathname) {
             config.enable_high_sensitivity =
                 object["enable_high_sensitivity"].GetBool();
           }
+          if (object.HasMember("frame_id") &&
+              object["frame_id"].IsString()) {
+            std::string bdc(config.broadcast_code);
+            map_frame_id.emplace(bdc, object["frame_id"].GetString());
+          }
 
           printf("broadcast code[%s] : %d %d %d %d %d %d\n",
                  config.broadcast_code, config.enable_connect,

--- a/livox_ros2_driver/livox_ros2_driver/livox_ros2_driver.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/livox_ros2_driver.cpp
@@ -194,6 +194,8 @@ void LivoxDriver::init()
 
     std::vector<std::string> bd_code_list;
     ParseCommandlineInputBdCode(cmdline_bd_code.c_str(), bd_code_list);
+    RCLCPP_INFO(this->get_logger(), "bd_code_list: %s", bd_code_list);
+    RCLCPP_INFO(this->get_logger(), "publish freq: %f", publish_freq);
 
     LdsLidar *read_lidar = LdsLidar::GetInstance(1000 / publish_freq);
     auto x = lddc_ptr_->RegisterLds(static_cast<Lds *>(read_lidar));

--- a/livox_ros2_driver/package.xml
+++ b/livox_ros2_driver/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>livox_ros2_driver</name>
+  <name>deepx_livox_ros2_driver</name>
   <version>0.0.1</version>
   <description>livox ros2 driver</description>
   <maintainer email="dev@livoxtech.com">feng</maintainer>


### PR DESCRIPTION
<!--
- Please fill the sections below and the PR metadata.
- Make it readable for reviewers and future visitors.
-->

### Description
<!--- Describe your changes in detail -->
- Add frame_id in config file,
- Set frame_id in PointCloud2 msgs by Lidar and not by node.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Be able to set frame_id by lidar when using one node to connect to several lidars and publishing their data in different topics.

### How Has This Been Tested?
<!--- Help reviewers by providing explanations, code snippets, checklists, etc. -->
- Tested on cpu-i-008.

<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
