### PR TITLE
Added CHANGELOG.md and described changes in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# CHANGELOG
+
+## [Unreleased]
+
+## [2025-01-11] - Toni Perälä
+
+### Fixed
+- Resolved a bug in the device broadcast address printing during initialization. Previously, the system printed a pointer instead of the actual device address. The array containing device broadcast addresses has been converted to a concatenated string that lists all whitelisted devices correctly.
+- Updated device IDs in all configuration files in the Livox workspace. 
+  - **Note**: For compatibility with `lidar_data_collection`, both `.json` and `.yaml` config files must include the device broadcast address.
+
+### Changed
+- Updated the package name in `CMakeLists.txt` and `package.xml`:
+  - From: `deepx_livox_ros2_driver`
+  - To: `livox_ros2_driver`
+  - **Reason**: This change ensures consistency, as all Livox ROS2 driver-related nodes called from launch files are named accordingly.
+- Set the current `.json` configuration for lidar launch to a test device.
+  - **Note**: A shell script feature is under development to automatically configure the device ID using `tcpdump` data during the build process in `lidar_data_collection`. For standalone use, ensure the correct device broadcast address is added manually.
+
+---

--- a/livox_ros2_driver/CMakeLists.txt
+++ b/livox_ros2_driver/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright(c) 2020 livoxtech limited.
 
 cmake_minimum_required(VERSION 3.5)
-project(deepx_livox_ros2_driver)
+project(livox_ros2_driver)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)

--- a/livox_ros2_driver/config/livox_lidar_config.json
+++ b/livox_ros2_driver/config/livox_lidar_config.json
@@ -1,17 +1,8 @@
 {
     "lidar_config": [
         {
-            "broadcast_code": "0T9DFBC00401611",
-            "enable_connect": false,
-            "enable_fan": true,
-            "return_mode": 0,
-            "coordinate": 0,
-            "imu_rate": 1,
-            "extrinsic_parameter_source": 0
-        },
-        {
-            "broadcast_code": "0TFDG3U99101431",
-            "enable_connect": false,
+            "broadcast_code": "3JEDK3U0011P871",
+            "enable_connect": true,
             "enable_fan": true,
             "return_mode": 0,
             "coordinate": 0,

--- a/livox_ros2_driver/launch/livox_lidar_launch.py
+++ b/livox_ros2_driver/launch/livox_lidar_launch.py
@@ -12,7 +12,7 @@ publish_freq  = 10.0 # freqency of publish,1.0,2.0,5.0,10.0,etc
 output_type   = 0
 frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
-cmdline_bd_code = 'livox0000000001'
+cmdline_bd_code = 'livox3JEDK3U0018B801'
 
 cur_path = os.path.split(os.path.realpath(__file__))[0] + '/'
 cur_config_path = cur_path + '../config'

--- a/livox_ros2_driver/livox_ros2_driver/livox_ros2_driver.cpp
+++ b/livox_ros2_driver/livox_ros2_driver/livox_ros2_driver.cpp
@@ -194,7 +194,12 @@ void LivoxDriver::init()
 
     std::vector<std::string> bd_code_list;
     ParseCommandlineInputBdCode(cmdline_bd_code.c_str(), bd_code_list);
-    RCLCPP_INFO(this->get_logger(), "bd_code_list: %s", bd_code_list);
+    
+    std::string bd_code_str;
+    for (const auto &code : bd_code_list) {
+    	bd_code_str += code + " ";
+    }
+    RCLCPP_INFO(this->get_logger(), "bd_code_list: %s", bd_code_str.c_str());
     RCLCPP_INFO(this->get_logger(), "publish freq: %f", publish_freq);
 
     LdsLidar *read_lidar = LdsLidar::GetInstance(1000 / publish_freq);

--- a/livox_ros2_driver/package.xml
+++ b/livox_ros2_driver/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>deepx_livox_ros2_driver</name>
+  <name>livox_ros2_driver</name>
   <version>0.0.1</version>
   <description>livox ros2 driver</description>
   <maintainer email="dev@livoxtech.com">feng</maintainer>


### PR DESCRIPTION
### Description
- Resolved a bug in the device broadcast address printing during initialization. Previously, the system printed a pointer instead of the actual device address. The array containing device broadcast addresses has been converted to a concatenated string that lists all whitelisted devices correctly.
- Updated device IDs in all configuration files in the Livox workspace. 
  - **Note**: For compatibility with `lidar_data_collection`, both `.json` and `.yaml` config files must include the device broadcast address.

This should be run in the future from a Docker container with all of this configured automatically by a .sh script launched during container boot.

### Motivation and Context
Issue with receiving data from Livox, issue with workspace layout
### How Has This Been Tested?
To test, pull relevant feature branch in lidar_data_collection repo, build, and try with a Livox Avia LiDAR on an experimental PC running the LiDAR to verify data capture.

<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
